### PR TITLE
Fix Python 3.9 incompatibility in CustomListDataset

### DIFF
--- a/datasets/custom_list.py
+++ b/datasets/custom_list.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import librosa
 import pandas as pd
+from typing import Optional
 from torch.utils.data import Dataset
 
 class CustomListDataset(Dataset):
@@ -14,7 +15,7 @@ class CustomListDataset(Dataset):
         n_fft: int = 1024,
         hop_length: int = 320,
         fmin: int = 0,
-        fmax: int | None = None,
+        fmax: Optional[int] = None,
         pad_seconds: float = 10.0,
         zscore: bool = True,
         mono: bool = True,


### PR DESCRIPTION
## Summary
- ensure CustomListDataset supports Python 3.9 by replacing PEP 604 union with `Optional`

## Testing
- `python -m py_compile datasets/custom_list.py`
- `python 16/save_features.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b89462a624832f963ac0a69ec6b0bc